### PR TITLE
Fix/json serializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>fr.insee.pogues</groupId>
 	<artifactId>pogues-model</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.5-SNAPSHOT</version>
+	<version>1.3.6-SNAPSHOT</version>
 	<name>Pogues Model</name>
 	<description>Classes and converters for the Pogues model</description>
 	<url>https://inseefr.github.io/Pogues-Model/</url>

--- a/src/main/java/fr/insee/pogues/conversion/JSONSerializer.java
+++ b/src/main/java/fr/insee/pogues/conversion/JSONSerializer.java
@@ -21,6 +21,12 @@ public class JSONSerializer {
 
 	public JSONSerializer() { }
 
+	public JSONSerializer(boolean withoutJsonRoot){
+		this.withoutJsonRoot = withoutJsonRoot;
+	}
+
+	private boolean withoutJsonRoot;
+
 	private static final Logger logger = LoggerFactory.getLogger(JSONSerializer.class);
 
 	public String serialize(Questionnaire questionnaire) throws JAXBException, UnsupportedEncodingException {
@@ -34,7 +40,7 @@ public class JSONSerializer {
 		marshaller.setProperty(MarshallerProperties.MEDIA_TYPE, "application/json");
 
 		// Set it to true if you need to include the JSON root element in the JSON output
-		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, true);
+		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, !withoutJsonRoot);
 		// Set it to true if you need the JSON output to formatted
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		// Marshal the questionnaire object to JSON and put the output in a string
@@ -57,7 +63,7 @@ public class JSONSerializer {
 		marshaller.setProperty(MarshallerProperties.MEDIA_TYPE, "application/json");
 
 		// Set it to true if you need to include the JSON root element in the JSON output
-		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, true);
+		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, !withoutJsonRoot);
 		// Set it to true if you need the JSON output to formatted
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		// Marshal the sequence object to JSON and put the output in a string
@@ -79,7 +85,7 @@ public class JSONSerializer {
 		marshaller.setProperty(MarshallerProperties.MEDIA_TYPE, "application/json");
 
 		// Set it to true if you need to include the JSON root element in the JSON output
-		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, true);
+		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, !withoutJsonRoot);
 		// Set it to true if you need the JSON output to formatted
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		// Marshal the code list object to JSON and put the output in a string
@@ -101,7 +107,7 @@ public class JSONSerializer {
 		marshaller.setProperty(MarshallerProperties.MEDIA_TYPE, "application/json");
 
 		// Set it to true if you need to include the JSON root element in the JSON output
-		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, true);
+		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, !withoutJsonRoot);
 		// Set it to true if you need the JSON output to formatted
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		// Marshal the code list object to JSON and put the output in a string
@@ -123,7 +129,7 @@ public class JSONSerializer {
 		marshaller.setProperty(MarshallerProperties.MEDIA_TYPE, "application/json");
 
 		// Set it to true if you need to include the JSON root element in the JSON output
-		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, true);
+		marshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, !withoutJsonRoot);
 		// Set it to true if you need the JSON output to formatted
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		// Marshal the code list object to JSON and put the output in a string

--- a/src/main/java/fr/insee/pogues/mock/QuestionnaireFactory.java
+++ b/src/main/java/fr/insee/pogues/mock/QuestionnaireFactory.java
@@ -1,12 +1,8 @@
 package fr.insee.pogues.mock;
 
+import fr.insee.pogues.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import fr.insee.pogues.model.ComponentGroup;
-import fr.insee.pogues.model.DataCollection;
-import fr.insee.pogues.model.Questionnaire;
-import fr.insee.pogues.model.SequenceType;
 
 public class QuestionnaireFactory {
 
@@ -59,6 +55,16 @@ public class QuestionnaireFactory {
 
 		logger.debug("Code list container added to questionnaire number " + questionnaireNumber);
 
+		return questionnaire;
+	}
+
+	public Questionnaire createMinimalQuestionnaire(){
+		Questionnaire questionnaire = new Questionnaire();
+		questionnaire.setId("test");
+		questionnaire.setAgency("Insee");
+		questionnaire.setFinal(true);
+		questionnaire.setName("Without root questionnaire");
+		questionnaire.setFlowLogic(FlowLogicEnum.FILTER);
 		return questionnaire;
 	}
 }

--- a/src/test/java/fr/insee/pogues/test/JSONSerializerTest.java
+++ b/src/test/java/fr/insee/pogues/test/JSONSerializerTest.java
@@ -192,6 +192,4 @@ class JSONSerializerTest {
 		JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
 	}
 
-
-
 }

--- a/src/test/java/fr/insee/pogues/test/JSONSerializerTest.java
+++ b/src/test/java/fr/insee/pogues/test/JSONSerializerTest.java
@@ -34,6 +34,40 @@ class JSONSerializerTest {
 	}
 
 	@Test
+	void testQuestionnaireWithOrWithoutRoot() throws Exception {
+
+		QuestionnaireFactory factory = new QuestionnaireFactory();
+		Questionnaire fakeQuestionnaire = factory.createMinimalQuestionnaire();
+
+		JSONSerializer serializer1 = new JSONSerializer();
+		JSONSerializer serializer2 = new JSONSerializer(true);
+		String withRoot = serializer1.serialize(fakeQuestionnaire);
+		String withoutRoot = serializer2.serialize(fakeQuestionnaire);
+
+		String expectedJsonWithRoot = """
+				{
+				    "Questionnaire": {
+				    	"id" : "test",
+				    	"agency" : "Insee",
+				    	"final" : true,
+				    	"flowLogic" : "FILTER",
+				    	"Name" : "Without root questionnaire"
+				    }
+				 }""";;
+
+		String expectedJsonWithoutRoot = """
+				{
+				    "id" : "test",
+				    "agency" : "Insee",
+				    "final" : true,
+				    "flowLogic" : "FILTER",
+				    "Name" : "Without root questionnaire"
+				 }""";
+		JSONAssert.assertEquals(expectedJsonWithRoot, withRoot, JSONCompareMode.STRICT);
+		JSONAssert.assertEquals(expectedJsonWithoutRoot, withoutRoot, JSONCompareMode.STRICT);
+	}
+
+	@Test
 	void testSequence() throws Exception {
 
 		SequenceFactory factory = new SequenceFactory();
@@ -157,5 +191,7 @@ class JSONSerializerTest {
 				}""";
 		JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
 	}
+
+
 
 }


### PR DESCRIPTION
Acutally, I remove in Pogues-Back-Office, useless dependencies (like marshaller to transform java to jsonString)

So now, I use only Pogues-Model methods.
But In pogues-back-office usage, we use the serialization without including json root : https://github.com/InseeFr/Pogues-Back-Office/blob/main/src/main/java/fr/insee/pogues/utils/PoguesSerializer.java#L31

This PR fix this issues.
We just have to call create JSONSerializer with the new attribute before serialize to String.

Thanks :)