### PR TITLE
Dev fixed length dynamic table

### DIFF
--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -335,18 +335,16 @@
     <xs:sequence>
       <xs:element name="CodeListReference" type="xs:token" minOccurs="0"/>
       <xs:element name="Label" type="xs:string" minOccurs="0"/>
-      <xs:element name="TotalLabel" type="xs:string" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Indicates if the dimension has a 'total' item and if yes the
-            corresponding label</xs:documentation>
-        </xs:annotation>
-      </xs:element>
+      <xs:element name="Minimum" type="xs:integer" minOccurs="0"/>
+      <xs:element name="Maximum" type="xs:integer" minOccurs="0"/>
+      <xs:element name="FixedLength" type="ExpressionType" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="dimensionType" type="DimensionTypeEnum" use="required"/>
-    <xs:attribute name="dynamic" type="xs:token" use="required">
+    <xs:attribute name="dynamic" type="xs:token">
       <xs:annotation>
-        <xs:documentation>'0': no constraint; 'm-': min m, no max; '-n': no min, n max; 'm-n': m
-          min, n max</xs:documentation>
+        <xs:documentation>previous modelization : '0': no constraint; 'm-': min m, no max; '-n': no min, n max; 'm-n': m min, n max</xs:documentation>
+        <xs:documentation>new modelization (not Enum because of the existing questionnaires) : NON_DYNAMIC (previously '0' ; default value) ; DYNAMIC_LENGTH (used with minimum and maximum)</xs:documentation>
+        <xs:documentation>new value : FIXED_LENGTH (used with FixedLength) : dynamic dimension with length fixed by a formula based on previous values</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -335,15 +335,15 @@
     <xs:sequence>
       <xs:element name="CodeListReference" type="xs:token" minOccurs="0"/>
       <xs:element name="Label" type="xs:string" minOccurs="0"/>
-      <xs:element name="Minimum" type="xs:integer" minOccurs="0"/>
-      <xs:element name="Maximum" type="xs:integer" minOccurs="0"/>
+      <xs:element name="MinLines" type="xs:integer" minOccurs="0"/>
+      <xs:element name="MaxLines" type="xs:integer" minOccurs="0"/>
       <xs:element name="FixedLength" type="ExpressionType" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="dimensionType" type="DimensionTypeEnum" use="required"/>
     <xs:attribute name="dynamic" type="xs:token">
       <xs:annotation>
         <xs:documentation>previous modelization : '0': no constraint; 'm-': min m, no max; '-n': no min, n max; 'm-n': m min, n max</xs:documentation>
-        <xs:documentation>new modelization (not Enum because of the existing questionnaires) : NON_DYNAMIC (previously '0' ; default value) ; DYNAMIC_LENGTH (used with minimum and maximum)</xs:documentation>
+        <xs:documentation>new modelization (not Enum because of the existing questionnaires) : NON_DYNAMIC (previously '0' ; default value) ; DYNAMIC_LENGTH (used with MinLines and MaxLines)</xs:documentation>
         <xs:documentation>new value : FIXED_LENGTH (used with FixedLength) : dynamic dimension with length fixed by a formula based on previous values</xs:documentation>
       </xs:annotation>
     </xs:attribute>


### PR DESCRIPTION
1) TotalLabel was never used -> removed
2) dynamic was always "0" for dimensions : secondary and measure -> removed in Pogues -> "required" removed
3) change of content of dynamic for "primary" dimension : 
- "0" -> "NON_DYNAMIC"
- "min-max" -> "DYNAMIC_LENGTH" ; min and max are saved in new elements MinLines and MaxLines
- new value for dynamic array with first dimension fixed by a formula : "FIXED_LENGTH" ; new element FixedLength containing the formula