### PR TITLE
fix: missing props for migration model (old->new)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>fr.insee.pogues</groupId>
 	<artifactId>pogues-model</artifactId>
-	<version>1.9.0</version>
+	<version>1.9.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Pogues Model</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>fr.insee.pogues</groupId>
 	<artifactId>pogues-model</artifactId>
-	<version>1.9.1-SNAPSHOT</version>
+	<version>1.9.1</version>
 	<packaging>jar</packaging>
 
 	<name>Pogues Model</name>

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -414,6 +414,12 @@
           <xs:documentation>Used only if dynamic = DYNAMIC_FIXED. Size dynamically fixed by a formula or a value (min = max).</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="FixedLength" type="ExpressionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>DEPRECATED: since 1.9.0</xs:documentation>
+          <xs:documentation>use "size" instead (VTL formula)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:sequence>
     <xs:attribute name="dimensionType" type="DimensionTypeEnum" use="required"/>
     <xs:attribute name="dynamic" type="xs:token">


### PR DESCRIPTION
Pour completer: https://github.com/InseeFr/Pogues-Model/pull/155 -> https://github.com/InseeFr/Pogues-Model/pull/155/files#diff-536eaff078ce649700c657551fcf6b2da59e901f83e785de5a342949527fb988L395

Il s'agit d'une correction de coquille, il ne fallait pas supprimer `FixedLength` finalement (je ne l'avais pas vu)