### PR TITLE
feat: loop with iteration pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>fr.insee.pogues</groupId>
 	<artifactId>pogues-model</artifactId>
-	<version>1.10.0-SNAPSHOT</version>
+	<version>1.10.0</version>
 	<packaging>jar</packaging>
 
 	<name>Pogues Model</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>fr.insee.pogues</groupId>
 	<artifactId>pogues-model</artifactId>
-	<version>1.9.3</version>
+	<version>1.10.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Pogues Model</name>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,10 @@
 					<sources>
 						<source>src/main/resources/xsd/Questionnaire.xsd</source>
 					</sources>
+					<arguments>
+						<argument>-b</argument>
+						<argument>src/main/resources/jaxb/bindings.xjb</argument>
+					</arguments>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/resources/jaxb/bindings.xjb
+++ b/src/main/resources/jaxb/bindings.xjb
@@ -4,5 +4,22 @@
         <jxb:schemaBindings>
             <jxb:package name="fr.insee.pogues.model"/>
         </jxb:schemaBindings>
+
+        <!-- Bindings spécifiques pour DynamicIterationType -->
+        <jxb:bindings node="//xs:complexType[@name='DynamicIterationType']/xs:complexContent/xs:extension/xs:sequence/xs:element[@name='Minimum']">
+            <jxb:property name="deprecatedMinimum"/>
+        </jxb:bindings>
+
+        <jxb:bindings node="//xs:complexType[@name='DynamicIterationType']/xs:complexContent/xs:extension/xs:sequence/xs:element[@name='Maximum']">
+            <jxb:property name="deprecatedMaximum"/>
+        </jxb:bindings>
+
+        <jxb:bindings node="//xs:complexType[@name='DynamicIterationType']/xs:complexContent/xs:extension/xs:sequence/xs:element[@name='minimum']">
+            <jxb:property name="minimum"/>
+        </jxb:bindings>
+
+        <jxb:bindings node="//xs:complexType[@name='DynamicIterationType']/xs:complexContent/xs:extension/xs:sequence/xs:element[@name='maximum']">
+            <jxb:property name="maximum"/>
+        </jxb:bindings>
     </jxb:bindings>
 </jxb:bindings>

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -249,8 +249,33 @@
     <xs:complexContent>
       <xs:extension base="IterationType">
         <xs:sequence>
-          <xs:element name="Minimum" type="ExpressionType" minOccurs="0"/>
-          <xs:element name="Maximum" type="ExpressionType" minOccurs="0"/>
+          <xs:element name="isFixedLength" type="xs:boolean" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Default value is false.
+                When there is no IterableReference, ables to know if a loop dimension is fixed (with a size value) or not (with minimum and maximum values)</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="minimum" type="ExpressionType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Minimum allowed value for a loop dimension. Used only if isFixedLength is false/undefined.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="maximum" type="ExpressionType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Maximum allowed value for a loop dimension. Used only if isFixedLength is false/undefined.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="size" type="ExpressionType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Size of a loop. Used only if isFixedLength is true.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="shouldSplitIterations" type="xs:boolean" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Default value is false.
+                When there is a size, it allows to display a loop with one page per iteration</xs:documentation>
+            </xs:annotation>
+          </xs:element>
           <xs:element name="Step" type="xs:nonNegativeInteger" minOccurs="0"/>
           <xs:element name="IterableReference" type="xs:token">
             <xs:annotation>

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -249,6 +249,18 @@
     <xs:complexContent>
       <xs:extension base="IterationType">
         <xs:sequence>
+          <xs:element name="Minimum" type="ExpressionType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>DEPRECATED: since 1.10.0</xs:documentation>
+              <xs:documentation>use "minimum" instead (VTL formula)</xs:documentation>
+          </xs:annotation>
+          </xs:element>
+          <xs:element name="Maximum" type="ExpressionType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>DEPRECATED: since 1.10.0</xs:documentation>
+              <xs:documentation>use "maximum" instead (VTL formula)</xs:documentation>
+            </xs:annotation>
+          </xs:element>
           <xs:element name="isFixedLength" type="xs:boolean" minOccurs="0">
             <xs:annotation>
               <xs:documentation>Default value is false.

--- a/src/test/java/fr/insee/pogues/test/JSONDeserializerTest.java
+++ b/src/test/java/fr/insee/pogues/test/JSONDeserializerTest.java
@@ -270,4 +270,60 @@ class JSONDeserializerTest {
 						.getResponseStructure().getDimension().getFirst()
 						.getMaximum().getValue());
 	}
+
+	@Test
+	public void shouldHandleMinMaxDynamicIteration_notCaseSensitive() throws JAXBException {
+		String oldJson = """
+				{
+				  "Iterations": {
+				  	"Iteration": [
+				  		{
+				  			"type": "DynamicIterationType",
+				  			"Minimum": "1",
+				  			"Maximum": "5"
+				  		}
+				  	]
+				  }
+				}
+				""";
+
+		String newJson = """
+				{
+				  "Iterations": {
+				  	"Iteration": [
+				  		{
+				  			"type": "DynamicIterationType",
+				  			"minimum": "1",
+				  			"maximum": "5",
+				  			"shouldSplitIterations": true
+				  		}
+				  	]
+				  }
+				}
+				""";
+		JSONDeserializer deserializer = new JSONDeserializer();
+		Questionnaire oldQuestionnaire = deserializer.deserializeString(oldJson);
+		assertEquals(
+				"1",
+				((DynamicIterationType) oldQuestionnaire.getIterations().getIteration().getFirst())
+						.getDeprecatedMinimum().getValue());
+		assertEquals(
+				"5",
+				((DynamicIterationType) oldQuestionnaire.getIterations().getIteration().getFirst())
+						.getDeprecatedMaximum().getValue());
+
+
+		Questionnaire newQuestionnaire = deserializer.deserializeString(newJson);
+		assertEquals(
+				"1",
+				((DynamicIterationType) newQuestionnaire.getIterations().getIteration().getFirst())
+						.getMinimum().getValue());
+		assertEquals(
+				"5",
+				((DynamicIterationType) newQuestionnaire.getIterations().getIteration().getFirst())
+						.getMaximum().getValue());
+		assertTrue(
+				((DynamicIterationType) newQuestionnaire.getIterations().getIteration().getFirst())
+						.isShouldSplitIterations());
+	}
 }

--- a/src/test/java/fr/insee/pogues/test/JSONSerializerTest.java
+++ b/src/test/java/fr/insee/pogues/test/JSONSerializerTest.java
@@ -536,4 +536,72 @@ class JSONSerializerTest {
 		JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
 	}
 
+	@Test
+	void serializeIterationPagination() throws JAXBException, UnsupportedEncodingException, JSONException {
+		Questionnaire questionnaire = new Questionnaire();
+		DynamicIterationType dynamicIterationType = new DynamicIterationType();
+		ExpressionType minimum = new ExpressionType();
+		minimum.setValue("1");
+		ExpressionType maximum = new ExpressionType();
+		maximum.setValue("5");
+		dynamicIterationType.setMinimum(minimum);
+		dynamicIterationType.setMaximum(maximum);
+		dynamicIterationType.setShouldSplitIterations(true);
+
+		Questionnaire.Iterations iterations = new Questionnaire.Iterations();
+		iterations.getIteration().add(dynamicIterationType);
+		questionnaire.setIterations(iterations);
+
+		JSONSerializer serializer = new JSONSerializer(true);
+		String result = serializer.serialize(questionnaire);
+		String expectedJson = """
+				{
+				  "Iterations": {
+				  	"Iteration": [
+				  		{
+				  			"type": "DynamicIterationType",
+				  			"minimum": "1",
+				  			"maximum": "5",
+				  			"shouldSplitIterations": true
+				  		}
+				  	]
+				  }
+				}
+				""";
+		JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
+	}
+
+	@Test
+	void serializeIterationPaginationFixedLength() throws JAXBException, UnsupportedEncodingException, JSONException {
+		Questionnaire questionnaire = new Questionnaire();
+		DynamicIterationType dynamicIterationType = new DynamicIterationType();
+		ExpressionType size = new ExpressionType();
+		size.setValue("42");
+		dynamicIterationType.setSize(size);
+		dynamicIterationType.setIsFixedLength(true);
+		dynamicIterationType.setShouldSplitIterations(true);
+
+		Questionnaire.Iterations iterations = new Questionnaire.Iterations();
+		iterations.getIteration().add(dynamicIterationType);
+		questionnaire.setIterations(iterations);
+
+		JSONSerializer serializer = new JSONSerializer(true);
+		String result = serializer.serialize(questionnaire);
+		String expectedJson = """
+				{
+				  "Iterations": {
+				  	"Iteration": [
+				  		{
+				  			"type": "DynamicIterationType",
+				  			"size": "42",
+				  			"isFixedLength": true,
+				  			"shouldSplitIterations": true
+				  		}
+				  	]
+				  }
+				}
+				""";
+		JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
+	}
+
 }


### PR DESCRIPTION
Improve loop model : 
- rename minimum/maximum (without uppercase)
- add isFixedLength + size : enable to set the loop dimension directly instead of a min/max
- add shouldSplitIterations : enable to do a loop with one page per iteration