### PR TITLE
fix: add VariableReference in variable for ucq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>fr.insee.pogues</groupId>
 	<artifactId>pogues-model</artifactId>
-	<version>1.15.1</version>
+	<version>1.16.0</version>
 	<packaging>jar</packaging>
 
 	<name>Pogues Model</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>fr.insee.pogues</groupId>
 	<artifactId>pogues-model</artifactId>
-	<version>1.16.0</version>
+	<version>1.15.2</version>
 	<packaging>jar</packaging>
 
 	<name>Pogues Model</name>

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -363,10 +363,11 @@
       <xs:element name="VariableReference" type="xs:token" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
-                VariableReference indicates the collected variable whose values
-                dynamically define the response options when the question
-                choiceType is set to VARIABLE.
-                It must not be used when choiceType is CODE_LIST.
+            Property defined on variables associated with a choice question, whose choices are 
+            dynamically defined by the responses of another question.
+            The value of the 'VariableRerference' property is the identifier of the variable defining 
+            these dynamic choices.
+            Therefore, it must only be used when the 'choiceType' in the associated question is 'VARIABLE'.
           </xs:documentation>
         </xs:annotation>
       </xs:element>

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -360,6 +360,7 @@
     </xs:annotation>
     <xs:sequence>
       <xs:element name="CodeListReference" type="xs:token" minOccurs="0"/>
+      <xs:element name="VariableReference" type="xs:token" minOccurs="0">
       <xs:element name="Datatype" type="DatatypeType">
         <xs:annotation>
           <xs:documentation>Variable representation type to characterize the variable (numeric,

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -224,7 +224,7 @@
           <xs:element name="sourceVariableReferences" type="SourceVariableReferences" minOccurs="0">
             <xs:annotation>
               <xs:documentation>References of variables used by pairwise
-              questions to define the indivisuals.</xs:documentation>
+              questions to define the individuals.</xs:documentation>
             </xs:annotation>
           </xs:element>
           <xs:element name="codeFilters" type="CodeFilter" minOccurs="0" maxOccurs="unbounded">
@@ -360,7 +360,16 @@
     </xs:annotation>
     <xs:sequence>
       <xs:element name="CodeListReference" type="xs:token" minOccurs="0"/>
-      <xs:element name="VariableReference" type="xs:token" minOccurs="0"/>
+      <xs:element name="VariableReference" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+                VariableReference indicates the collected variable whose values
+                dynamically define the response options when the question
+                choiceType is set to VARIABLE.
+                It must not be used when choiceType is CODE_LIST.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="Datatype" type="DatatypeType">
         <xs:annotation>
           <xs:documentation>Variable representation type to characterize the variable (numeric,
@@ -601,7 +610,7 @@
   <xs:complexType name="ResponseType">
     <xs:sequence>
       <xs:element name="CodeListReference" type="xs:token" minOccurs="0"/>
-      <xs:element name="VariableReference" type="xs:token" minOccurs="0"/>
+      <xs:element name="VariableReference" type="xs:token" minOccurs="0">
        <xs:annotation>
          <xs:documentation>
          VariableReference indicates the collected variable whose values

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -360,7 +360,7 @@
     </xs:annotation>
     <xs:sequence>
       <xs:element name="CodeListReference" type="xs:token" minOccurs="0"/>
-      <xs:element name="VariableReference" type="xs:token" minOccurs="0">
+      <xs:element name="VariableReference" type="xs:token" minOccurs="0"/>
       <xs:element name="Datatype" type="DatatypeType">
         <xs:annotation>
           <xs:documentation>Variable representation type to characterize the variable (numeric,
@@ -601,7 +601,7 @@
   <xs:complexType name="ResponseType">
     <xs:sequence>
       <xs:element name="CodeListReference" type="xs:token" minOccurs="0"/>
-      <xs:element name="VariableReference" type="xs:token" minOccurs="0">
+      <xs:element name="VariableReference" type="xs:token" minOccurs="0"/>
        <xs:annotation>
          <xs:documentation>
          VariableReference indicates the collected variable whose values

--- a/src/test/java/fr/insee/pogues/test/JSONDeserializerTest.java
+++ b/src/test/java/fr/insee/pogues/test/JSONDeserializerTest.java
@@ -544,4 +544,34 @@ class JSONDeserializerTest {
                 question.getResponse().getFirst().getVariableReference()
         );
     }
+
+    @Test
+    void testDeserializeVariableReferenceInExternalVariable() throws JAXBException {
+
+        String json = """
+            {
+                "Variables": {
+                    "Variable": [
+                        {
+                            "id": "ext1",
+                            "type": "ExternalVariableType",
+                            "VariableReference": "id-variable-ref",
+                            "Name": "NUMERO_MENAGE",
+                            "Label": "Numéro du ménage"
+                        }
+                    ]
+                }
+            }
+            """;
+
+        JSONDeserializer deserializer = new JSONDeserializer();
+        Questionnaire questionnaire = deserializer.deserializeString(json);
+
+        ExternalVariableType variable =
+                (ExternalVariableType) questionnaire.getVariables()
+                        .getVariable().getFirst();
+
+        assertNotNull(variable);
+        assertEquals("id-variable-ref", variable.getVariableReference());
+    }
 }

--- a/src/test/java/fr/insee/pogues/test/JSONSerializerTest.java
+++ b/src/test/java/fr/insee/pogues/test/JSONSerializerTest.java
@@ -714,4 +714,40 @@ class JSONSerializerTest {
 
         JSONAssert.assertEquals(expectedJson, json, JSONCompareMode.STRICT);
     }
+
+    @Test
+    void testSerializeVariableReferenceInExternalVariable() throws Exception {
+
+        ExternalVariableType variable = new ExternalVariableType();
+        variable.setId("ext1");
+        variable.setName("NUMERO_MENAGE");
+        variable.setLabel("Numéro du ménage");
+        variable.setVariableReference("id-variable-ref");
+
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setVariables(new Questionnaire.Variables());
+
+        questionnaire.getVariables().getVariable().add(variable);
+
+        JSONSerializer serializer = new JSONSerializer(true);
+        String json = serializer.serialize(questionnaire);
+
+        String expectedJson = """
+    {
+      "Variables": {
+        "Variable": [
+          {
+            "id": "ext1",
+            "type": "ExternalVariableType",
+            "VariableReference": "id-variable-ref",
+            "Name": "NUMERO_MENAGE",
+            "Label": "Numéro du ménage"
+          }
+        ]
+      }
+    }
+    """;
+
+        JSONAssert.assertEquals(expectedJson, json, JSONCompareMode.STRICT);
+    }
 }


### PR DESCRIPTION
This property is required for the "variable choices in unique choice question" feature, it was missing