### PR TITLE
fix: set OptionFilter in the response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>fr.insee.pogues</groupId>
 	<artifactId>pogues-model</artifactId>
-	<version>1.15.3</version>
+	<version>1.15.4</version>
 	<packaging>jar</packaging>
 
 	<name>Pogues Model</name>

--- a/src/main/resources/xsd/Questionnaire.xsd
+++ b/src/main/resources/xsd/Questionnaire.xsd
@@ -233,15 +233,6 @@
                 codeValue filtered according to a condition</xs:documentation>
             </xs:annotation>
           </xs:element>
-          <xs:element name="OptionFilter" type="xs:string" minOccurs="0">
-            <xs:annotation>
-              <xs:documentation>
-                OptionFilter defines a VTL expression used to dynamically filter
-                response options when the choiceType is set to VARIABLE.
-                For CODE_LIST questions, filtering must be defined at the individual
-                option level.</xs:documentation>
-            </xs:annotation>
-          </xs:element>
         </xs:sequence>
         <xs:attribute name="questionType" type="QuestionTypeEnum"/>
         <xs:attribute name="mandatory" type="xs:boolean">
@@ -620,6 +611,15 @@
          It must not be used when choiceType is CODE_LIST.
          </xs:documentation>
        </xs:annotation>
+      </xs:element>
+      <xs:element name="OptionFilter" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            OptionFilter defines a VTL expression used to dynamically filter
+            response options when the choiceType is set to VARIABLE.
+            For CODE_LIST questions, filtering must be defined at the individual
+            option level.</xs:documentation>
+        </xs:annotation>
       </xs:element>
       <xs:element name="Datatype" type="DatatypeType"/>
       <xs:element name="Value" type="xs:anyType" minOccurs="0" maxOccurs="unbounded"/>

--- a/src/test/java/fr/insee/pogues/model/UniqueChoiceVariableOptionsTest.java
+++ b/src/test/java/fr/insee/pogues/model/UniqueChoiceVariableOptionsTest.java
@@ -19,10 +19,10 @@ class UniqueChoiceVariableOptionsTest {
         // Given
         QuestionType question = new QuestionType();
         question.setQuestionType(QuestionTypeEnum.SINGLE_CHOICE);
-        question.setOptionFilter("nvl($AGE$, 0) > 18");
 
         ResponseType response = new ResponseType();
         response.setVariableReference("id-loop-variable");
+        response.setOptionFilter("nvl($AGE$, 0) > 18");
         response.setChoiceType(ChoiceTypeEnum.VARIABLE);
 
         question.getResponse().add(response);
@@ -40,10 +40,10 @@ class UniqueChoiceVariableOptionsTest {
             {
               "type": "QuestionType",
               "questionType": "SINGLE_CHOICE",
-              "OptionFilter": "nvl($AGE$, 0) > 18",
               "Response": [
                 {
                   "VariableReference": "id-loop-variable",
+                  "OptionFilter": "nvl($AGE$, 0) > 18",
                   "choiceType": "VARIABLE"
                 }
               ]
@@ -100,7 +100,7 @@ class UniqueChoiceVariableOptionsTest {
         QuestionType question = (QuestionType) questionnaire.getChild().getFirst();
         assertEquals(QuestionTypeEnum.SINGLE_CHOICE, question.getQuestionType());
         assertEquals(ChoiceTypeEnum.VARIABLE, question.getResponse().getFirst().getChoiceType());
-        assertNull(question.getOptionFilter());
+        assertNull(question.getResponse().getFirst().getOptionFilter());
         assertNotNull(question.getResponse());
         assertFalse(question.getResponse().isEmpty()) ;
         assertEquals("id-loop-variable", question.getResponse().getFirst().getVariableReference());
@@ -114,10 +114,10 @@ class UniqueChoiceVariableOptionsTest {
                  {
                    "type": "QuestionType",
                    "questionType": "SINGLE_CHOICE",
-                   "OptionFilter": "nvl($AGE$, 0) > 18",
                    "Response": {
                        "choiceType": "VARIABLE",
-                       "VariableReference": "id-loop-variable"
+                       "VariableReference": "id-loop-variable",
+                       "OptionFilter": "nvl($AGE$, 0) > 18"
                    }
                  }
                ]
@@ -130,7 +130,7 @@ class UniqueChoiceVariableOptionsTest {
         QuestionType question = (QuestionType) questionnaire.getChild().getFirst();
         assertEquals(QuestionTypeEnum.SINGLE_CHOICE, question.getQuestionType());
         assertEquals(ChoiceTypeEnum.VARIABLE, question.getResponse().getFirst().getChoiceType());
-        assertEquals("nvl($AGE$, 0) > 18", question.getOptionFilter());
+        assertEquals("nvl($AGE$, 0) > 18", question.getResponse().getFirst().getOptionFilter());
         assertNotNull(question.getResponse());
         assertFalse(question.getResponse().isEmpty()) ;
         assertEquals("id-loop-variable", question.getResponse().getFirst().getVariableReference());


### PR DESCRIPTION
As we changed `VariableReference` to be in the response instead of the question (necessary for tables), we need the same for `OptionFilter`